### PR TITLE
fix(install): [git] make `postinstall` script work with git install

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "fix:dedupe": "yarn dedupe --strategy=highest",
     "fix:format": "prettier --cache --write .",
     "fix:lint": "yarn check:lint --cache --fix",
-    "postinstall": "chmod +x .husky/* && husky install",
+    "postinstall": "[ -f ./node_modules/.bin/husky ] && chmod +x .husky/* && husky install || exit 0",
     "postpack": "toggle-scripts +postinstall",
     "postpublish": "toggle-scripts +prepack",
     "prepack": "toggle-scripts -postinstall && yarn build",


### PR DESCRIPTION
## Description

<!-- A clear and concise description of your changes. -->

Makes `postinstall` script work as expected when package is installed from git.

The script now checks for the existence of `./node_modules/bin/husky` before attempting to install `husky`.

## Tests

<!-- What did you test? List tests, include snippet from test suites, or write "N/A" if tests were not needed. -->

`postinstall` script works as expected. see #11 for details.

## Linked issues

<!--
A list of linked issues and/or pull requests.

- <closes|fixes|resolves> #<issue-number>
- <prereleases|releases> #<pr-number>
-->

- fixes #11 

## Related documents

<!-- A list of related documents (e.g. docs, proposals, specs, etc), if any. -->

N/A

## Additional context

<!--
Include additional details here. Be sure to note if any tolerable vulnerabilities or warnings have been introduced.
-->

N/A

## Submission checklist

- [x] self-review performed
- [x] tests added and/or updated
- [x] documentation added or updated
- [x] new, **tolerable** vulnerabilities and/or warnings documented, if any
- [x] [pr naming conventions][1]

[1]: https://github.com/flex-development/docast-parse/blob/main/CONTRIBUTING.md#pull-request-titles
